### PR TITLE
feat: Taking partial profit order with stop-loss at entry price

### DIFF
--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -309,6 +309,29 @@ TODO: This file should be split into smaller components.
             </dd>
         </div>
 
+        <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-4 px-6" >
+            <dt class="text-sm font-medium text-gray-500" >
+                Take partial profit and move stoploss.
+            </dt>
+            <dd class="mt-1 text-sm text-gray-900 mt-0" >
+                <Checkbox @bind-Checked=@TakeProfitAndUpdateStoploss OnChange=@(() => StateHasChanged()) />
+            </dd>
+        </div>
+
+        @if (TakeProfitAndUpdateStoploss)
+        {
+            <div class="bg-white-50 px-4 py-2" >
+                <Alert Type=@(AlertType.Warning) >
+                    <p>
+                        "Take partial profit and move stoploss." is a <b>Exprimental</b> feature and should be used at your own risk.
+                    </p>
+                    <p>
+                        Please consult the documentation before enabling this feature as it could have side-effects you should be familiar with before usage.
+                    </p>
+                </Alert>
+            </div>
+        }
+
     </div>
 </TabPane>
 </ChildContent>

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -173,6 +173,15 @@ TODO: This file should be split into smaller components.
                 </dd>
             </div>
 
+            <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-4 px-6" >
+                <dt class="text-sm font-medium text-gray-500" >
+                    Take partial profit and move stoploss.
+                </dt>
+                <dd class="mt-1 text-sm text-gray-900 mt-0" >
+                    <Checkbox @bind-Checked=@TakeProfitAndUpdateStoploss OnChange=@(() => OnTakeProfitAndUpdateStoplossChange()) />
+                </dd>
+            </div>
+
             <div class="bg-white-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
                 <Button Type="@ButtonType.Primary"
                         Disabled=!AllowPlaceOrder
@@ -217,6 +226,23 @@ TODO: This file should be split into smaller components.
                 </div>
             }
 
+            @if (TakeProfitAndUpdateStoploss && !HideTakeProfitAndUpdateStoplossWarning)
+            {
+                <div class="bg-white-50 px-4 py-2" >
+                    <Alert Type=@(AlertType.Warning)  CloseText="Don't show again" Closable OnClose=@(() => OnTakeProfitAndUpdateStoplossWarningClose())>
+                        <p>
+                            "Take partial profit and move stoploss." is a <b>exprimental</b> feature and should be used at your own risk.
+                        </p>
+                    <p>
+                        <i>
+                            When this is activated there will be a 50% position LIMIT SELL at 2x the risk and when this is activated the stop-loss
+                            order will be updated to entry with the remaining 50% of the position.
+                        </i> 
+                    </p>
+                    </Alert>
+                </div>
+            }
+            
             @if (Cost > BuyingPower)
             {
                 <div class="bg-gray-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
@@ -308,30 +334,6 @@ TODO: This file should be split into smaller components.
                 <Checkbox @bind-Checked=@UseLowOfDayAsStopLoss OnChange=@(() => StateHasChanged()) />
             </dd>
         </div>
-
-        <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-4 px-6" >
-            <dt class="text-sm font-medium text-gray-500" >
-                Take partial profit and move stoploss.
-            </dt>
-            <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                <Checkbox @bind-Checked=@TakeProfitAndUpdateStoploss OnChange=@(() => StateHasChanged()) />
-            </dd>
-        </div>
-
-        @if (TakeProfitAndUpdateStoploss)
-        {
-            <div class="bg-white-50 px-4 py-2" >
-                <Alert Type=@(AlertType.Warning) >
-                    <p>
-                        "Take partial profit and move stoploss." is a <b>Exprimental</b> feature and should be used at your own risk.
-                    </p>
-                    <p>
-                        Please consult the documentation before enabling this feature as it could have side-effects you should be familiar with before usage.
-                    </p>
-                </Alert>
-            </div>
-        }
-
     </div>
 </TabPane>
 </ChildContent>

--- a/Server/Commands/PlaceOrderCommand.cs
+++ b/Server/Commands/PlaceOrderCommand.cs
@@ -16,5 +16,7 @@ namespace traderui.Server.Commands
         public double StopLossAt { get; set; }
         public bool Transmit { get; set; } = false;
         public ContractDetails ContractDetails { get; set; } = new();
+        public bool TakeProfitAndUpdateSellorder { get; set; }
+        public double TakeProfitAt { get; set; }
     }
 }

--- a/Server/InteractiveBrokers/EWrapperImplementation.cs
+++ b/Server/InteractiveBrokers/EWrapperImplementation.cs
@@ -171,6 +171,14 @@ public class EWrapperImplementation : EWrapper
 
     public void orderStatus(int orderId, string status, double filled, double remaining, double avgFillPrice, int permId, int parentId, double lastFillPrice, int clientId, string whyHeld, double mktCapPrice)
     {
+        // When the order is filled, we check to see if there are any
+        // child orders that should be updated with the correct size
+        // due to Bracket orders default to full position.
+        if (status.Equals("Filled"))
+        {
+            _broker.ModifyProfitOrderWithCorrectQuantity(orderId, filled);
+        }
+
         _brokerHub.Clients.All.SendAsync(nameof(OrderStatusMessage), new OrderStatusMessage
         {
             OrderId = orderId,

--- a/Server/InteractiveBrokers/IInteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/IInteractiveBrokers.cs
@@ -16,6 +16,7 @@ namespace traderui.Server.IBKR
         void GetPositions();
         void GetAccountSummary(bool stopRequest);
         bool IsConnected();
+        void ModifyProfitOrderWithCorrectQuantity(int orderId, double filled);
         void Connect();
     }
 }

--- a/Shared/Requests/PlaceOrderRequest.cs
+++ b/Shared/Requests/PlaceOrderRequest.cs
@@ -14,5 +14,7 @@ namespace traderui.Shared.Requests
         public double StopLossAt { get; set; }
         public bool Transmit { get; set; } = false;
         public ContractDetails ContractDetails { get; set; } = new();
+        public bool TakeProfitAndUpdateSellorder { get; set; } = false;
+        public double TakeProfitAt { get; set; }
     }
 }

--- a/Shared/WebOrder.cs
+++ b/Shared/WebOrder.cs
@@ -14,4 +14,6 @@ public class WebOrder
     public double StopLossAt { get; set; }
     public bool Transmit { get; set; } = false;
     public ContractDetails ContractDetails { get; set; } = new();
+    public bool TakeProfitAndUpdateSellorder { get; set; }
+    public double TakeProfitAt { get; set; }
 }


### PR DESCRIPTION
This is a attempt to implement a partial profit strategy allowing for taking profit at the 2x risk and moving the stoploss for the remaining position to the entry. 

Making this work with IBKR is tricky as there is no straight forward way of accomplishing this without some side effects (read on).

The logic implemented is as follows: 

On entry, there will be four orders transmitted to the exchange, but there are only three expected to be executed. 

1. `BUY` order 
2. Our partial `ProfitTaker` order, at 2x the risk with half the size of the filled BUY order
3. A `STP` order with the same size as the `ProfitTaker` order.
4. A `STP` order at full size of the initial `BUY` order.

These orders will look like this in IBKR TWS:
![image](https://user-images.githubusercontent.com/27571840/161142370-dca2fdf3-706c-422d-8f23-b007a88a72b7.png)

The two `STP` and the `ProfitTaker` orders are in a [One-Cancel-All](https://interactivebrokers.github.io/tws-api/oca.html) group so we'll always end up with only one stop-loss. The first to hit cancel the others. 

The problem with this approach is that TWS default to a full size position when taking profit with a bracket order (2), and it will also use the same size for the stop-loss triggered after the profit (3). To prevent this we wait for the `BUY` order (1) to get filled and update the `ProfitTaker` order with half of the filled amount, and we use the same for the stop-loss (3). 

This works out if the filled amount is even, if not we'll end up shorting 1 position, and this is where it gets tricky. Since we don't know when the profit order will be filled we can't take for granted that we can catch the "filled"-event from TWS since the program might not run, or whatever reason. It's also likely that we'll not get a even fill.

To enable this feature, check the "Take partial profit and move stoploss.". I would recommend not transmitting before validating the configuration manually in TWS. Also, take note that the profit order is updated with correct size.

![image](https://user-images.githubusercontent.com/27571840/161144905-6679338c-2a31-4cf8-bc35-6881a19017d3.png)

A pre-compiled binary may be downloaded from here: [traderui_0.1.1-alpha.0.3+9fc208e.zip](https://github.com/aklepaker/traderui/suites/5884769422/artifacts/198938665)
