### PR TITLE
fix: Removed redundant GetHistoricalBarData requests

### DIFF
--- a/Client/Pages/Index.razor.cs
+++ b/Client/Pages/Index.razor.cs
@@ -134,10 +134,6 @@ namespace traderui.Client.Pages
             });
 
             TempSymbol = await localStorage.GetItemAsync<string>("symbol");
-            if (!string.IsNullOrWhiteSpace(TempSymbol))
-            {
-                OnSymbolChange();
-            }
 
             HubConnection connection = new HubConnectionBuilder()
                 .WithUrl(new Uri($"{NavigationManager.Uri}hub/broker"))
@@ -375,7 +371,6 @@ namespace traderui.Client.Pages
             AdrData.Clear();
             Symbol = TempSymbol;
             await BrokerService.GetTicker(Symbol, CancellationToken.None);
-            await BrokerService.GetHistoricalBarData(Symbol, AdrBarDataRequest, CancellationToken.None);
             StateHasChanged();
         }
 


### PR DESCRIPTION
`GetHistoricalBarData` was requested twice when the ticker changed and this PR remove this duplicate call to the `GetHistoricalBarData` method.