### PR TITLE
fix: Connect to TWS when signalR connection established

### DIFF
--- a/Server/Hubs/BrokerHub.cs
+++ b/Server/Hubs/BrokerHub.cs
@@ -20,6 +20,7 @@ public class BrokerHub : Hub
     {
         if (!_broker.IsConnected())
         {
+            _broker.Connect();
             Clients.All.SendAsync(nameof(TWSDisconnectedMessage), new TWSDisconnectedMessage());
         }
         else

--- a/Server/InteractiveBrokers/IInteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/IInteractiveBrokers.cs
@@ -16,5 +16,6 @@ namespace traderui.Server.IBKR
         void GetPositions();
         void GetAccountSummary(bool stopRequest);
         bool IsConnected();
+        void Connect();
     }
 }

--- a/Server/InteractiveBrokers/InteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/InteractiveBrokers.cs
@@ -51,7 +51,7 @@ namespace traderui.Server.IBKR
             return _client.IsConnected();
         }
 
-        private void Connect()
+        public void Connect()
         {
             var readerSignal = _impl.Signal;
             if (_client.IsConnected())


### PR DESCRIPTION
When the client connects to the backend we connect to the TWR if we're in a disconnected state.