### PR TITLE
feat: Show trading volume for the day in percentage relative to the 90 days average

### DIFF
--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -81,6 +81,17 @@ TODO: This file should be split into smaller components.
                             </div>
                         }
 
+                        @if (Volume / AvgVolume > 0)
+                        {
+                            <div>
+                                Volume
+                            </div>
+                            <div title=@($"Calculated from current volume ({Volume.ToString("#,##0,M", CultureInfo.InvariantCulture)}) divided by average volume last 90 days ({AvgVolume.ToString("#,##0,M", CultureInfo.InvariantCulture)})") >
+                                @Helper.TwoDecimal((Volume / AvgVolume) * 100)%
+                            </div>
+                        }
+                        
+
                     </div>
                 }
             </div>

--- a/Client/Pages/Index.razor.cs
+++ b/Client/Pages/Index.razor.cs
@@ -38,6 +38,8 @@ namespace traderui.Client.Pages
         public double AskPrice { get; set; }
         public double LowOfDay { get; set; }
         public double HighOfDay { get; set; }
+        public double Volume { get; set; }
+        public double AvgVolume { get; set; }
         public bool UseLowOfDayAsStopLoss { get; set; }
         public double BidPrice { get; set; }
         public double ClosePrice { get; set; }
@@ -372,6 +374,23 @@ namespace traderui.Client.Pages
                     PriceLoaded = true;
                     RecalculateNumbers();
                 }
+            });
+
+            connection.On(nameof(TickSizeMessage), (TickSizeMessage tickSizeMessage) =>
+            {
+                switch (tickSizeMessage.Field)
+                {
+                    case 8:
+                        Volume = tickSizeMessage.Size * ContractDetails.MdSizeMultiplier;
+                        break;
+                    case 21:
+                        AvgVolume = tickSizeMessage.Size * ContractDetails.MdSizeMultiplier;
+                        break;
+                }
+            });
+
+            connection.On(nameof(TickGenericMessage), (TickGenericMessage tickGenericMessage) =>
+            {
             });
 
             connection.On(nameof(TickByTickBidAskMessage), (TickByTickBidAskMessage tickByTickBidAskEvent) =>

--- a/Server/InteractiveBrokers/EWrapperImplementation.cs
+++ b/Server/InteractiveBrokers/EWrapperImplementation.cs
@@ -89,6 +89,12 @@ public class EWrapperImplementation : EWrapper
 
     public void tickSize(int tickerId, int field, int size)
     {
+        _brokerHub.Clients.All.SendAsync(nameof(TickSizeMessage), new TickSizeMessage
+        {
+            TickerId = tickerId,
+            Field = field,
+            Size = size,
+        });
     }
 
     public void tickString(int tickerId, int field, string value)
@@ -97,6 +103,12 @@ public class EWrapperImplementation : EWrapper
 
     public void tickGeneric(int tickerId, int field, double value)
     {
+        _brokerHub.Clients.All.SendAsync(nameof(TickGenericMessage), new TickGenericMessage
+        {
+            TickerId = tickerId,
+            Field = field,
+            Value = value,
+        });
     }
 
     public void tickEFP(int tickerId, int tickType, double basisPoints, string formattedBasisPoints, double impliedFuture, int holdDays, string futureLastTradeDate, double dividendImpact, double dividendsToLastTradeDate)

--- a/Server/InteractiveBrokers/InteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/InteractiveBrokers.cs
@@ -282,7 +282,7 @@ namespace traderui.Server.IBKR
             GetPriceRequestStack.Add(name, requestId);
 
             Log.Information("Requested market data for {name}", name);
-            _client.reqMktData(requestId, contract, "221", false, false, null);
+            _client.reqMktData(requestId, contract, "165, 221,233,295,595", false, false, null);
             _client.reqHistoricalData(requestId, contract, String.Empty, "1 D", "1 day", "TRADES", 1, 1, true, null);
         }
 

--- a/Shared/Messages/TickGenericMessage.cs
+++ b/Shared/Messages/TickGenericMessage.cs
@@ -1,0 +1,6 @@
+public class TickGenericMessage
+{
+    public int TickerId { get; set; }
+    public int Field { get; set; }
+    public double Value { get; set; }
+}

--- a/Shared/Messages/TickSizeMessage.cs
+++ b/Shared/Messages/TickSizeMessage.cs
@@ -1,0 +1,6 @@
+public class TickSizeMessage
+{
+    public int TickerId { get; set; }
+    public int Field { get; set; }
+    public int Size { get; set; }
+}


### PR DESCRIPTION
The current volume relative to the 90 days average will be displayed in the top left together with ADR and time updated. 

90 days average is not optimal - but this is what IBKR have available without any manual computation