### PR TITLE
devops: Added docker image to release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.dockerignore
+.env
+.vs
+.vscode
+docker-compose.yml
+docker-compose.*.yml
+Dockerfile
+**/bin
+**/obj
+**/node_modules
+**/build

--- a/.github/workflows/TraderUI_Build.yml
+++ b/.github/workflows/TraderUI_Build.yml
@@ -55,16 +55,16 @@ jobs:
           Start-Process msiexec.exe -Wait -ArgumentList "/x $env:TEMP\TWS_API.msi /quiet /qn"
           Remove-Item -Path $env:TEMP"\TWS_API.msi"
 
-      - name: Artifact binaries
+      - name: Upload repo with IBKR source
         uses: actions/upload-artifact@v2
         with:
           name: Repo_${{ steps.version.outputs.filever }}
           path: .
           retention-days: 1
           
-#      - name: Publish
-#        run: |
-#          dotnet publish .\Server\traderui.Server.csproj -c Release -r win-x64 --self-contained -o .\Publish
+      - name: Publish
+        run: |
+          dotnet publish .\Server\traderui.Server.csproj -c Release -r win-x64 --self-contained -o .\Publish
 
       - name: Upload Binaries
         uses: actions/upload-artifact@v2
@@ -92,5 +92,5 @@ jobs:
 
       - name: Docker Build and Push
         run: |
-          docker build . -f ./Dockerfile -t ghcr.io/aklepaker/traderui:${{ needs.build.outputs.version_tag }}
-          docker push ghcr.io/aklepaker/traderui:${{ needs.build.outputs.version_tag }}
+          docker build . -f ./Dockerfile -t ghcr.io/aklepaker/traderui:${{ needs.build.outputs.version_number }}
+          docker push ghcr.io/aklepaker/traderui:${{ needs.build.outputs.version_number }}

--- a/.github/workflows/TraderUI_Build.yml
+++ b/.github/workflows/TraderUI_Build.yml
@@ -4,11 +4,18 @@ on:
   push:
     tags:
       - '*'
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  Tests:
+  build:
     name: Release
     runs-on: windows-latest
+    outputs:
+      version_tag: ${{ steps.version.outputs.tag }}
+      version_number: ${{ steps.version.outputs.version }}
+      version_number_short: ${{ steps.version.outputs.filever }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,6 +45,7 @@ jobs:
           echo "::set-output name=version::${{ steps.minver.outputs.version }}"
           echo "::set-output name=semver::${{ steps.minver.outputs.major }}.${{ steps.minver.outputs.minor }}.${{ steps.minver.outputs.patch }}"
           echo "::set-output name=filever::${{ steps.minver.outputs.major }}.${{ steps.minver.outputs.minor }}.${{ steps.minver.outputs.patch }}.${{ github.run_number }}"
+          echo "::set-output name=tag::${{ steps.minver.outputs.major }}.${{ steps.minver.outputs.minor }}.${{ steps.minver.outputs.patch }}.${{ github.run_number }}-${{ steps.short-sha.outputs.sha }}"          
 
       - name: Download IBKR API
         run: |
@@ -47,13 +55,42 @@ jobs:
           Start-Process msiexec.exe -Wait -ArgumentList "/x $env:TEMP\TWS_API.msi /quiet /qn"
           Remove-Item -Path $env:TEMP"\TWS_API.msi"
 
-      - name: Publish
-        run: |
-          dotnet publish .\Server\traderui.Server.csproj -c Release -o .\Publish
+      - name: Artifact binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: Repo_${{ steps.version.outputs.filever }}
+          path: .
+          retention-days: 1
+          
+#      - name: Publish
+#        run: |
+#          dotnet publish .\Server\traderui.Server.csproj -c Release -r win-x64 --self-contained -o .\Publish
 
       - name: Upload Binaries
         uses: actions/upload-artifact@v2
         with:
-          name: traderui_${{ steps.version.outputs.version }}.zip
+          name: traderui_${{ steps.version.outputs.version }}
           path: .\Publish\**
           retention-days: 30
+
+  docker:
+    name: Docker image
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - uses: actions/download-artifact@v2
+        with:
+          name: Repo_${{  needs.build.outputs.version_number_short }}
+          path: .
+
+      - name: Docker Build and Push
+        run: |
+          docker build . -f ./Dockerfile -t ghcr.io/aklepaker/traderui:${{ needs.build.outputs.version_tag }}
+          docker push ghcr.io/aklepaker/traderui:${{ needs.build.outputs.version_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build API
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+COPY . /traderui
+WORKDIR /traderui
+RUN dotnet restore Server/traderui.Server.csproj
+RUN dotnet publish Server/traderui.Server.csproj -r linux-x64 -c Release -o out --self-contained true -p:PublishTrimmed=false
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
+WORKDIR /traderui
+COPY --from=build-env /traderui/out .
+ENTRYPOINT ["dotnet", "traderui.dll", "--urls", "http://0.0.0.0:5000"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@ This software is provided as is and should be used at your own risk. For one rea
 This software could for whatever reason and at any point be archived or discontinued.
 
 ## Start
+### Windows
 Start the application by running the `traderui.exe` file from the build, or downloaded release. From your favorite browser open `http://localhost:5000`
+
+### Docker
+You may also run this with Docker, but be sure to set correct Server address (the IP of the machine running TWS) and ensure to update the tag of the image to correct version.
+
+`docker run -it --rm --name tradeui -p 5000:5000 -e "ServerOptions:Server=192.168.1.2" tradeui:0.2.1.22-5816236`
+
+Remember to update the TWS settings allowing for non-localhost addresses and add the IP of the docker host.
+
+![image](https://user-images.githubusercontent.com/27571840/165388593-da5d3c5d-2a8d-4cd1-b441-67e3ce16db41.png)
+
 
 ## TODOs
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -12,21 +12,22 @@ using traderui.Server.IBKR;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var logConfiguration = builder.Configuration
+var configuration = builder.Configuration
     .SetBasePath(Environment.CurrentDirectory)
     .AddJsonFile("appsettings.json")
+    .AddEnvironmentVariables()
     .Build();
 
 builder.Host.UseSerilog((context, config) =>
 {
-    config.ReadFrom.Configuration(logConfiguration);
+    config.ReadFrom.Configuration(configuration);
 });
 
 Log.Logger = new LoggerConfiguration()
-    .ReadFrom.Configuration(logConfiguration)
+    .ReadFrom.Configuration(configuration)
     .CreateLogger();
 
-builder.Services.Configure<ServerOptions>(builder.Configuration.GetSection(nameof(ServerOptions)));
+builder.Services.Configure<ServerOptions>(configuration.GetSection(nameof(ServerOptions)));
 builder.Services.AddMediatR(typeof(Program));
 builder.Services.AddAutoMapper(typeof(Program));
 builder.Services.AddControllersWithViews();

--- a/Server/traderui.Server.csproj
+++ b/Server/traderui.Server.csproj
@@ -6,11 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>traderui</AssemblyName>
   </PropertyGroup>
-    
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' AND '$(OS)' == 'Windows_NT' ">
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <DebugType>embedded</DebugType>

--- a/Shared/traderui.Shared.csproj
+++ b/Shared/traderui.Shared.csproj
@@ -5,9 +5,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' AND '$(OS)' == 'Windows_NT' ">
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <DebugType>embedded</DebugType>

--- a/traderui.sln
+++ b/traderui.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFiles", "SolutionFi
 		Directory.Build.props = Directory.Build.props
 		README.md = README.md
 		.gitignore = .gitignore
+		Dockerfile = Dockerfile
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{3BFD34F4-35E2-4C48-A03D-BE6F3DCC3A62}"


### PR DESCRIPTION
You may also run this with Docker, but be sure to set correct Server address (the IP of the machine running TWS) and ensure to update the tag of the image to correct version.

`docker run -it --rm --name tradeui -p 5000:5000 -e "ServerOptions:Server=192.168.1.2" ghcr.io/aklepaker/traderui:0.2.1.22-5816236`

Remember to update the TWS settings allowing for non-localhost addresses and add the IP of the docker host.

![image](https://user-images.githubusercontent.com/27571840/165388593-da5d3c5d-2a8d-4cd1-b441-67e3ce16db41.png)
