### PR TITLE
feat: Added conditional market order

### DIFF
--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -160,6 +160,7 @@ TODO: This file should be split into smaller components.
                     <RadioGroup @bind-Value="@OrderType" >
                         <Radio Value=@OrderType.LMT >Limit</Radio>
                         <Radio Value=@OrderType.MKT >Market</Radio>
+                        <Radio Value=@OrderType.MKT_CONDITIONAL >Conditional Market</Radio>
                     </RadioGroup>
                 </dd>
             </div>

--- a/Server/InteractiveBrokers/InteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/InteractiveBrokers.cs
@@ -332,6 +332,18 @@ namespace traderui.Server.IBKR
                 // }
             };
 
+            if (webOrder.OrderType == OrderType.MKT_CONDITIONAL)
+            {
+                order.OrderType = OrderType.MKT.ToString();
+
+                PriceCondition priceCondition = (PriceCondition)OrderCondition.Create(OrderConditionType.Price);
+                priceCondition.ConId = webOrder.ContractDetails.Contract.ConId;
+                priceCondition.Exchange = webOrder.ContractDetails.Contract.Exchange;
+                priceCondition.IsMore = true;
+                priceCondition.Price = Math.Round(webOrder.LmtPrice, 2, MidpointRounding.AwayFromZero);
+                order.Conditions.Add(priceCondition);
+            }
+
             _client.placeOrder(order.OrderId, webOrder.ContractDetails.Contract, order);
             Log.Information("Placed {OrderType} buy order on {Symbol} for {NumberOfOrders} at {Price}", order.OrderType, webOrder.ContractDetails.Contract.Symbol, order.TotalQuantity, order.LmtPrice);
 

--- a/Shared/OrderType.cs
+++ b/Shared/OrderType.cs
@@ -5,6 +5,7 @@ namespace traderui.Shared
         MKT = 0,
         LMT,
         STP,
-        STPLMT
+        STPLMT,
+        MKT_CONDITIONAL
     }
 }


### PR DESCRIPTION
Added conditional market order, to be triggered at the given price.

Note: The value of the STP order will not be updated when the order is filled - so your STP will be the one used when submitting the order to the exchange. 

![image](https://user-images.githubusercontent.com/27571840/176269440-31646e30-f4da-45b4-9234-e17670ce6b6d.png)
