### PR TITLE
feat: Use SignalR groups splitting symbol data

### DIFF
--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -9,12 +9,13 @@
 @using traderui.Client.Services
 @using traderui.Shared
 @using System.Globalization
+@using Microsoft.AspNetCore.Connections
 
 @*
 TODO: This file should be split into smaller components.
 *@
 
-
+<PageTitle>@Symbol?.ToUpper()</PageTitle>
 <Tabs Type="@TabType.Card" >
 
 <TabBarExtraContent>
@@ -30,276 +31,277 @@ TODO: This file should be split into smaller components.
 <ChildContent>
 <TabPane Key="1" Tab="Trading" >
 <div class="bg-white overflow-hidden" @onclick=@(() => OnReceivedFocus()) >
-    <div class="grid grid-rows-2 grid-flow-col px-4 py-2 h-24" >
-        <div class="row-span-2 col-span-2 justify-self-stretch" >
+<div class="grid grid-rows-2 grid-flow-col px-4 py-2 h-24" >
+    <div class="row-span-2 col-span-2 justify-self-stretch" >
+        @if (SymbolLoaded)
+        {
+            <h3 class="text-lg leading-6 font-medium text-gray-900" >
+                @ContractDetails.Contract.Symbol (@ContractDetails.Contract.PrimaryExch)
+            </h3>
+            <p class="mt-1 max-w-2xl text-sm text-gray-500" >
+                @ContractDetails.LongName - @ContractDetails.Industry
+                <p>
+                    @ContractDetails.Category - @ContractDetails.Subcategory
+                </p>
+            </p>
+        }
+        else
+        {
+            <h3>No symbol</h3>
+        }
+    </div>
+    <div class="row-start-1 col-span-1 justify-self-end" >
+        <div class="grid grid-rows-3 grid-flow-col text-xs" >
             @if (SymbolLoaded)
             {
-                <h3 class="text-lg leading-6 font-medium text-gray-900" >
-                    @ContractDetails.Contract.Symbol (@ContractDetails.Contract.PrimaryExch)
-                </h3>
-                <p class="mt-1 max-w-2xl text-sm text-gray-500" >
-                    @ContractDetails.LongName - @ContractDetails.Industry
-                    <p>
-                        @ContractDetails.Category - @ContractDetails.Subcategory
-                    </p>
+                <div class="grid grid-cols-2 grid-flow-row gap-1" >
+                    <div>
+                        Updated:
+                    </div>
+                    <div>
+                        <b>@DateTimeUpdated.ToString("HH:mm:ss")</b>
+                    </div>
+                    @if (AdrData.AverageDailyRange > 0)
+                    {
+                        <div>
+                            ADR
+                        </div>
+                        <div class="text-@(AdrData.AverageDailyRange >= 5 ? "green" : "red")-500" >
+                            @Helper.Percent(AdrData.AverageDailyRange)%
+                        </div>
+                    }
+
+                    @if (Size > 0)
+                    {
+                        var ratio = (((Price * Size) * (1 + (RiskRatioTarget / 100))) - (Price * Size)) / ((Price * Size) - (StopLossAt * Size));
+                        <div>
+                            RR (@RiskRatioTarget)%
+                        </div>
+                        <div class="text-@(ratio >= 3 ? "green" : "red")-500" >
+                            1:@Helper.TwoDecimal(ratio)
+                        </div>
+                    }
+
+                    @if (Volume / AvgVolume > 0)
+                    {
+                        <div>
+                            Volume
+                        </div>
+                        <div title=@($"Calculated from current volume ({Volume.ToString("#,##0,M", CultureInfo.InvariantCulture)}) divided by average volume last 90 days ({AvgVolume.ToString("#,##0,M", CultureInfo.InvariantCulture)})") >
+                            @Helper.TwoDecimal((Volume / AvgVolume) * 100)%
+                        </div>
+                    }
+
+
+                </div>
+            }
+        </div>
+    </div>
+</div>
+<div class="border-t border-gray-200" >
+<dl>
+
+    <div class="bg-gray-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            Ticker
+
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <AntDesign.Input @ref="tickerInput" name="Symbol"
+                             @bind-value=TempSymbol DefaultValue=@Symbol
+                             On=@(() => OnSymbolChange()) 
+                             OnPressEnter=@(() => OnSymbolChange()) style="width: 100px" Min="0" />
+            <Button Type="@ButtonType.Primary" OnClick=@OnResetPriceClick >Reset</Button>
+        </dd>
+    </div>
+    <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            @(!string.IsNullOrWhiteSpace(PriceType) ? $"{PriceType} price" : "Price")
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <AntDesign.Input name="Price"
+                             @ref="priceInput"
+                             Value=@Price
+                             DefaultValue=@Price
+                             OnChange="@((double value) => OnOverridePriceChange(value))"
+                             OnBlur=@(() => RecalculateNumbers())
+                             style="width: 100px" Min="0" >
+                <AddOnBefore>$</AddOnBefore>
+            </AntDesign.Input>
+        </dd>
+    </div>
+
+    <div class="bg-gray-50 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            Stop-Loss
+            <div class="text-xs" >
+                @StopLossType
+            </div>
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <AntDesign.Input name="Size" Value=@(StopLossAt) DefaultValue="@StopLossAt" OnChange=@((double v) => OnStopLossChange(v)) style="width: 100px" >
+                <AddOnBefore>$</AddOnBefore>
+            </AntDesign.Input>
+        </dd>
+    </div>
+
+    <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            Size
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <AntDesign.InputNumber name="Size" Value="@Size" DefaultValue="@Size" ValueChanged=@((double v) => OnSizeChange(v)) style="width: 100px" Min="0" />
+        </dd>
+    </div>
+
+    <div class="bg-gray-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            Order type
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <RadioGroup @bind-Value="@OrderType" >
+                <Radio Value=@OrderType.LMT >Limit</Radio>
+                <Radio Value=@OrderType.MKT >Market</Radio>
+                <Radio Value=@OrderType.MKT_CONDITIONAL >Conditional Market</Radio>
+            </RadioGroup>
+        </dd>
+    </div>
+
+    <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            Transmitt Order
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <Switch @bind-Checked=@TransmitOrder >Transmit Order </Switch>
+        </dd>
+    </div>
+
+    @* <div class="bg-gray-50 px-4 py-2 grid grid-cols-2 gap-4 px-6" > *@
+    @*     <dt class="text-sm font-medium text-gray-500" > *@
+    @*         Place order as a *@
+    @*     </dt> *@
+    @*     <dd class="mt-1 text-sm text-gray-900 mt-0" > *@
+    @*         <Switch @bind-Checked=@IsBuyOrder OnChange=@(() => RecalculateNumbers()) > *@
+    @*             <CheckedChildrenTemplate> *@
+    @*                 BUY ORDER *@
+    @*             </CheckedChildrenTemplate> *@
+    @*             <UnCheckedChildrenTemplate> *@
+    @*                 SELL ORDER *@
+    @*             </UnCheckedChildrenTemplate> *@
+    @*         </Switch> *@
+    @*     </dd> *@
+    @* </div> *@
+
+    <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+        <dt class="text-sm font-medium text-gray-500" >
+            Take partial profit and move stoploss.
+        </dt>
+        <dd class="mt-1 text-sm text-gray-900 mt-0" >
+            <Checkbox @bind-Checked=@TakeProfitAndUpdateStoploss OnChange=@(() => OnTakeProfitAndUpdateStoplossChange()) />
+        </dd>
+    </div>
+
+    @if (TakeProfitAndUpdateStoploss)
+    {
+        <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
+            <dt class="text-sm font-medium text-gray-500" >
+                Profit target
+            </dt>
+            <dd class="mt-1 text-sm text-gray-900 mt-0" >
+                <div class="grid grid-cols-2 grid-flow-row text-xs" >
+                    <div>
+                        <AntDesign.Input name="Size" Value=@TakeProfitAtPercent DefaultValue=@TakeProfitAtPercent ValueChanged=@((double v) => OnTakeProfitAtPercentChange(v)) style="width: 70px" Min="0" >
+                            <AddOnBefore>%</AddOnBefore>
+                        </AntDesign.Input>
+                    </div>
+                    <div>
+                        <AntDesign.Input name="Size" Value=@TakeProfitAt DefaultValue=@TakeProfitAt ValueChanged=@((double v) => OnTakeProfitAtChange(v)) style="width: 75px" Min="0" >
+                            <AddOnBefore>$</AddOnBefore>
+                        </AntDesign.Input>
+                    </div>
+                </div>
+            </dd>
+        </div>
+    }
+
+    <div class="bg-white-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
+        <Button Type="@ButtonType.Primary"
+                Disabled=!AllowPlaceOrder
+                OnClick=PlaceOrder
+                Block
+                Danger=@(IsBuyOrder != true) >
+            @(IsBuyOrder ? "BUY" : "SELL")
+        </Button>
+    </div>
+
+    @if (IsBuyOrder && AdrData.AverageDailyRange > 0 && Math.Round(100 * ((MarketPrice / StopLossAt) - 1), 2) >= Math.Round(AdrData.AverageDailyRange, 2))
+    {
+        <div class="bg-gray-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
+            <Alert Type=@AlertType.Warning >
+                <p>
+                    You're violating the ADR rule stating that the difference (@Helper.Percent((100 * ((MarketPrice / StopLossAt) - 1)))%) between the ASK price and your Stop-Loss should not be greater than the ADR
+                    (@Helper.Percent(AdrData.AverageDailyRange)%).
                 </p>
-            }
-            else
-            {
-                <h3>No symbol</h3>
-            }
+                The Stop-Loss should be no lower than @Helper.CurrencyFormat((MarketPrice / (1 + (AdrData.AverageDailyRange) / 100)) + 0.01)
+            </Alert>
         </div>
-        <div class="row-start-1 col-span-1 justify-self-end" >
-            <div class="grid grid-rows-3 grid-flow-col text-xs" >
-                @if (SymbolLoaded)
+    }
+
+    @if (AllowPlaceOrder)
+    {
+        <div class="bg-white-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
+            <Alert Type=@(IsBuyOrder ? AlertType.Info : AlertType.Error) >
+                You are about to @(IsBuyOrder ? "buy" : "sell") <b>@Size</b> shares of <b>@Symbol?.ToUpper()</b> at <b>@(Helper.CurrencyFormat(Price))</b> for a total of <b>@(Helper.CurrencyFormat(Cost))</b>.
+                @if (IsBuyOrder)
                 {
-                    <div class="grid grid-cols-2 grid-flow-row gap-1" >
-                        <div>
-                            Updated:
-                        </div>
-                        <div>
-                            <b>@DateTimeUpdated.ToString("HH:mm:ss")</b>
-                        </div>
-                        @if (AdrData.AverageDailyRange > 0)
-                        {
-                            <div>
-                                ADR
-                            </div>
-                            <div class="text-@(AdrData.AverageDailyRange >= 5 ? "green" : "red")-500" >
-                                @Helper.Percent(AdrData.AverageDailyRange)%
-                            </div>
-                        }
-
-                        @if (Size > 0)
-                        {
-                            var ratio = (((Price * Size) * (1 + (RiskRatioTarget / 100))) - (Price * Size)) / ((Price * Size) - (StopLossAt * Size));
-                            <div>
-                                RR (@RiskRatioTarget)%
-                            </div>
-                            <div class="text-@(ratio >= 3 ? "green" : "red")-500" >
-                                1:@Helper.TwoDecimal(ratio)
-                            </div>
-                        }
-
-                        @if (Volume / AvgVolume > 0)
-                        {
-                            <div>
-                                Volume
-                            </div>
-                            <div title=@($"Calculated from current volume ({Volume.ToString("#,##0,M", CultureInfo.InvariantCulture)}) divided by average volume last 90 days ({AvgVolume.ToString("#,##0,M", CultureInfo.InvariantCulture)})") >
-                                @Helper.TwoDecimal((Volume / AvgVolume) * 100)%
-                            </div>
-                        }
-                        
-
-                    </div>
+                    <span>
+                        Stop-loss at <b>@(Helper.CurrencyFormat(StopLossAt))</b> (@(Helper.Percent((1 - (StopLossAt / Price)) * 100))%) giving a max loss for this trade at <b>@(Helper.CurrencyFormat(MaxLoss))</b>.
+                    </span>
                 }
-            </div>
+
+                @if (TakeProfitAndUpdateStoploss)
+                {
+                    <span>
+                        Partial profit enabled at <b>$@(TakeProfitAt)</b> giving a profit of <b>@(Helper.CurrencyFormat((TakeProfitAt - Price) * Size / 2))</b>
+                    </span>
+                }
+                <br />
+                @if (!IsBuyOrder)
+                {
+                    <br />
+                    <b>Warning: Ensure you own the stocks, else they will be shorted</b>
+                }
+            </Alert>
         </div>
-    </div>
-    <div class="border-t border-gray-200" >
-        <dl>
+    }
 
-            <div class="bg-gray-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    Ticker
+    @if (TakeProfitAndUpdateStoploss && !HideTakeProfitAndUpdateStoplossWarning)
+    {
+        <div class="bg-white-50 px-4 py-2" >
+            <Alert Type=@(AlertType.Warning) CloseText="Don't show again" Closable OnClose=@(() => OnTakeProfitAndUpdateStoplossWarningClose()) >
+                <p>
+                    "Take partial profit and move stoploss." is a <b>exprimental</b> feature and should be used at your own risk.
+                </p>
+                <p>
+                    <i>
+                        When this is activated there will be a 50% position LIMIT SELL at 2x the risk and when this is activated the stop-loss
+                        order will be updated to entry with the remaining 50% of the position.
+                    </i>
+                </p>
+            </Alert>
+        </div>
+    }
 
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <AntDesign.Input @ref="tickerInput" name="Symbol"
-                                     @bind-value=TempSymbol DefaultValue=@Symbol
-                                     OnPressEnter=@(() => OnSymbolChange()) style="width: 100px" Min="0" />
-                    <Button Type="@ButtonType.Primary" OnClick=@OnResetPriceClick >Reset</Button>
-                </dd>
-            </div>
-            <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    @(!string.IsNullOrWhiteSpace(PriceType) ? $"{PriceType} price" : "Price")
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <AntDesign.Input name="Price"
-                                     @ref="priceInput"
-                                     Value=@Price
-                                     DefaultValue=@Price
-                                     OnChange="@((double value) => OnOverridePriceChange(value))"
-                                     OnBlur=@(() => RecalculateNumbers())
-                                     style="width: 100px" Min="0" >
-                        <AddOnBefore>$</AddOnBefore>
-                    </AntDesign.Input>
-                </dd>
-            </div>
-
-            <div class="bg-gray-50 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    Stop-Loss
-                    <div class="text-xs" >
-                        @StopLossType
-                    </div>
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <AntDesign.Input name="Size" Value=@(StopLossAt) DefaultValue="@StopLossAt" OnChange=@((double v) => OnStopLossChange(v)) style="width: 100px">
-                        <AddOnBefore>$</AddOnBefore>
-                    </AntDesign.Input>
-                    </dd>
-            </div>
-
-            <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    Size
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <AntDesign.InputNumber name="Size" Value="@Size" DefaultValue="@Size" ValueChanged=@((double v) => OnSizeChange(v)) style="width: 100px" Min="0" />
-                </dd>
-            </div>
-
-            <div class="bg-gray-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    Order type
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <RadioGroup @bind-Value="@OrderType" >
-                        <Radio Value=@OrderType.LMT >Limit</Radio>
-                        <Radio Value=@OrderType.MKT >Market</Radio>
-                        <Radio Value=@OrderType.MKT_CONDITIONAL >Conditional Market</Radio>
-                    </RadioGroup>
-                </dd>
-            </div>
-
-            <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    Transmitt Order
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <Switch @bind-Checked=@TransmitOrder >Transmit Order </Switch>
-                </dd>
-            </div>
-
-            @* <div class="bg-gray-50 px-4 py-2 grid grid-cols-2 gap-4 px-6" > *@
-            @*     <dt class="text-sm font-medium text-gray-500" > *@
-            @*         Place order as a *@
-            @*     </dt> *@
-            @*     <dd class="mt-1 text-sm text-gray-900 mt-0" > *@
-            @*         <Switch @bind-Checked=@IsBuyOrder OnChange=@(() => RecalculateNumbers()) > *@
-            @*             <CheckedChildrenTemplate> *@
-            @*                 BUY ORDER *@
-            @*             </CheckedChildrenTemplate> *@
-            @*             <UnCheckedChildrenTemplate> *@
-            @*                 SELL ORDER *@
-            @*             </UnCheckedChildrenTemplate> *@
-            @*         </Switch> *@
-            @*     </dd> *@
-            @* </div> *@
-
-            <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                <dt class="text-sm font-medium text-gray-500" >
-                    Take partial profit and move stoploss.
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                    <Checkbox @bind-Checked=@TakeProfitAndUpdateStoploss OnChange=@(() => OnTakeProfitAndUpdateStoplossChange()) />
-                </dd>
-            </div>
-
-            @if (TakeProfitAndUpdateStoploss)
-            {
-                <div class="bg-white-50 px-4 py-2 grid grid-cols-2 gap-2 px-6" >
-                    <dt class="text-sm font-medium text-gray-500" >
-                        Profit target
-                    </dt>
-                    <dd class="mt-1 text-sm text-gray-900 mt-0" >
-                        <div class="grid grid-cols-2 grid-flow-row text-xs" >
-                            <div>
-                                <AntDesign.Input name="Size" Value=@TakeProfitAtPercent DefaultValue=@TakeProfitAtPercent ValueChanged=@((double v) => OnTakeProfitAtPercentChange(v)) style="width: 70px" Min="0" >
-                                    <AddOnBefore>%</AddOnBefore>
-                                </AntDesign.Input>
-                            </div>
-                            <div>
-                                <AntDesign.Input name="Size" Value=@TakeProfitAt DefaultValue=@TakeProfitAt ValueChanged=@((double v) => OnTakeProfitAtChange(v)) style="width: 75px" Min="0" >
-                                    <AddOnBefore>$</AddOnBefore>
-                                </AntDesign.Input>
-                            </div>
-                        </div>
-                    </dd>
-                </div>
-            }
-
-            <div class="bg-white-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
-                <Button Type="@ButtonType.Primary"
-                        Disabled=!AllowPlaceOrder
-                        OnClick=PlaceOrder
-                        Block
-                        Danger=@(IsBuyOrder != true) >
-                    @(IsBuyOrder ? "BUY" : "SELL")
-                </Button>
-            </div>
-
-            @if (IsBuyOrder && AdrData.AverageDailyRange > 0 && Math.Round(100 * ((MarketPrice / StopLossAt) - 1), 2) >= Math.Round(AdrData.AverageDailyRange, 2))
-            {
-                <div class="bg-gray-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
-                    <Alert Type=@AlertType.Warning >
-                        <p>
-                            You're violating the ADR rule stating that the difference (@Helper.Percent((100 * ((MarketPrice / StopLossAt) - 1)))%) between the ASK price and your Stop-Loss should not be greater than the ADR
-                            (@Helper.Percent(AdrData.AverageDailyRange)%).
-                        </p>
-                        The Stop-Loss should be no lower than @Helper.CurrencyFormat((MarketPrice / (1 + (AdrData.AverageDailyRange) / 100)) + 0.01)
-                    </Alert>
-                </div>
-            }
-
-            @if (AllowPlaceOrder)
-            {
-                <div class="bg-white-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
-                    <Alert Type=@(IsBuyOrder ? AlertType.Info : AlertType.Error) >
-                        You are about to @(IsBuyOrder ? "buy" : "sell") <b>@Size</b> shares of <b>@Symbol?.ToUpper()</b> at <b>@(Helper.CurrencyFormat(Price))</b> for a total of <b>@(Helper.CurrencyFormat(Cost))</b>. 
-                        @if (IsBuyOrder)
-                        {
-                            <span>
-                                Stop-loss at <b>@(Helper.CurrencyFormat(StopLossAt))</b> (@(Helper.Percent((1 - (StopLossAt / Price)) * 100))%) giving a max loss for this trade at <b>@(Helper.CurrencyFormat(MaxLoss))</b>.
-                            </span>
-                        }
-
-                        @if (TakeProfitAndUpdateStoploss)
-                        {
-                            <span>
-                            Partial profit enabled at <b>$@(TakeProfitAt)</b> giving a profit of <b>@(Helper.CurrencyFormat((TakeProfitAt - Price) * Size / 2))</b> 
-                            </span>
-                        }
-                        <br/>
-                        @if (!IsBuyOrder)
-                        {
-                            <br />
-                            <b>Warning: Ensure you own the stocks, else they will be shorted</b>
-                        }
-                    </Alert>
-                </div>
-            }
-
-            @if (TakeProfitAndUpdateStoploss && !HideTakeProfitAndUpdateStoplossWarning)
-            {
-                <div class="bg-white-50 px-4 py-2" >
-                    <Alert Type=@(AlertType.Warning)  CloseText="Don't show again" Closable OnClose=@(() => OnTakeProfitAndUpdateStoplossWarningClose())>
-                        <p>
-                            "Take partial profit and move stoploss." is a <b>exprimental</b> feature and should be used at your own risk.
-                        </p>
-                    <p>
-                        <i>
-                            When this is activated there will be a 50% position LIMIT SELL at 2x the risk and when this is activated the stop-loss
-                            order will be updated to entry with the remaining 50% of the position.
-                        </i> 
-                    </p>
-                    </Alert>
-                </div>
-            }
-            
-            @if (Cost > BuyingPower)
-            {
-                <div class="bg-gray-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
-                    <Alert Type=@(AlertType.Error) >
-                        Your cost for this trade exceeds @(Helper.CurrencyFormat(BuyingPower)) with @(Helper.CurrencyFormat(Math.Round(Cost - BuyingPower, 2, MidpointRounding.AwayFromZero)))
-                    </Alert>
-                </div>
-            }
-        </dl>
-    </div>
+    @if (Cost > BuyingPower)
+    {
+        <div class="bg-gray-50 px-4 py-2 grid grid-cols-1 gap-4 px-6" >
+            <Alert Type=@(AlertType.Error) >
+                Your cost for this trade exceeds @(Helper.CurrencyFormat(BuyingPower)) with @(Helper.CurrencyFormat(Math.Round(Cost - BuyingPower, 2, MidpointRounding.AwayFromZero)))
+            </Alert>
+        </div>
+    }
+</dl>
+</div>
 </div>
 </TabPane>
 <TabPane Key="2" Tab="Positions" >

--- a/Client/Pages/Index.razor.cs
+++ b/Client/Pages/Index.razor.cs
@@ -29,7 +29,7 @@ namespace traderui.Client.Pages
 
         public DateTime DateTimeUpdated { get; set; }
         public string Symbol { get; set; }
-        public string TempSymbol { get; set; }
+        public string TempSymbol { get; set; } = String.Empty;
         public bool SymbolLoaded { get; set; }
         public bool PriceLoaded { get; set; }
         public ContractDetails ContractDetails { get; set; }
@@ -150,6 +150,7 @@ namespace traderui.Client.Pages
 
         public double OverrideTakeProfitAtPercent { get; set; } = 0;
 
+        public HubConnection Connection { get; set; }
         protected override async void OnInitialized()
         {
             AdrBarDataRequest = _randomNumberGenerator.Next();
@@ -176,41 +177,43 @@ namespace traderui.Client.Pages
 
             TempSymbol = await localStorage.GetItemAsync<string>("symbol");
 
-            HubConnection connection = new HubConnectionBuilder()
+            Connection = new HubConnectionBuilder()
                 .WithUrl(new Uri($"{NavigationManager.Uri}hub/broker"))
                 .WithAutomaticReconnect()
                 .Build();
 
-            connection.Closed += (e) =>
+            Connection.Closed += (e) =>
+            {
+                // await BrokerService.CancelSubscriptions(CancellationToken.None);
+                IsConnectedToTws = false;
+                StateHasChanged();
+                return null;
+            };
+
+            Connection.Reconnecting += (e) =>
             {
                 IsConnectedToTws = false;
                 StateHasChanged();
                 return null;
             };
 
-            connection.Reconnecting += (e) =>
+            Connection.Reconnected += async (connectionId) =>
             {
-                IsConnectedToTws = false;
-                StateHasChanged();
-                return null;
-            };
-
-            connection.Reconnected += async (connectionId) =>
-            {
-                await BrokerService.CancelSubscriptions(CancellationToken.None);
+                // await BrokerService.CancelSubscriptions(CancellationToken.None);
                 await BrokerService.GetPositions(CancellationToken.None);
                 await BrokerService.GetAccountSummary(false, CancellationToken.None);
+                BrokerService.SetConnectionId(Connection.ConnectionId);
                 IsConnectedToTws = true;
                 StateHasChanged();
             };
 
-            connection.On(nameof(TWSDisconnectedMessage), (TWSDisconnectedMessage message) =>
+            Connection.On(nameof(TWSDisconnectedMessage), (TWSDisconnectedMessage message) =>
             {
                 IsConnectedToTws = false;
                 StateHasChanged();
             });
 
-            connection.On(nameof(TWSConnectedMessage), (TWSConnectedMessage message) =>
+            Connection.On(nameof(TWSConnectedMessage), (TWSConnectedMessage message) =>
             {
                 IsConnectedToTws = true;
                 ApplicationVersion = message.Version;
@@ -218,7 +221,7 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(ContractDetailsMessage), async (ContractDetailsMessage contractDetailsEvent) =>
+            Connection.On(nameof(ContractDetailsMessage), async (ContractDetailsMessage contractDetailsEvent) =>
             {
                 AdrData.Clear();
                 ContractDetails = contractDetailsEvent.ContractDetails;
@@ -231,7 +234,7 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(ErrorCodeMessage), async (ErrorCodeMessage errorCodeEvent) =>
+            Connection.On(nameof(ErrorCodeMessage), async (ErrorCodeMessage errorCodeEvent) =>
             {
                 switch (errorCodeEvent.ErrorCode)
                 {
@@ -244,12 +247,12 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(ConnectAckMessage), (ConnectAckMessage connectAckEvent) =>
+            Connection.On(nameof(ConnectAckMessage), (ConnectAckMessage connectAckEvent) =>
             {
                 AddLogMessage(connectAckEvent.Message);
             });
 
-            connection.On(nameof(PositionMessage), async (PositionMessage positionEvent) =>
+            Connection.On(nameof(PositionMessage), async (PositionMessage positionEvent) =>
             {
                 Position position = new Position
                 {
@@ -271,13 +274,13 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(HistoricalDataUpdateMessage), (HistoricalDataUpdateMessage historicalDataUpdateEvent) =>
+            Connection.On(nameof(HistoricalDataUpdateMessage), (HistoricalDataUpdateMessage historicalDataUpdateEvent) =>
             {
                 HighOfDay = historicalDataUpdateEvent.Bar.High;
                 LowOfDay = historicalDataUpdateEvent.Bar.Low;
             });
 
-            connection.On(nameof(HistoricalDataMessage), (HistoricalDataMessage historicalDataEvent) =>
+            Connection.On(nameof(HistoricalDataMessage), (HistoricalDataMessage historicalDataEvent) =>
             {
                 if (historicalDataEvent.RequestId.Equals(AdrBarDataRequest))
                 {
@@ -285,15 +288,16 @@ namespace traderui.Client.Pages
                 }
             });
 
-            connection.On(nameof(HistoricalDataEndMessage), (HistoricalDataEndMessage historicalDataEndEvent) =>
+            Connection.On(nameof(HistoricalDataEndMessage), (HistoricalDataEndMessage historicalDataEndEvent) =>
             {
                 if (historicalDataEndEvent.RequestId == AdrBarDataRequest)
                 {
                     AdrData.CalculateDailyRange();
+                    StateHasChanged();
                 }
             });
 
-            connection.On(nameof(PnlMessage), (PnlMessage pnlEvent) =>
+            Connection.On(nameof(PnlMessage), (PnlMessage pnlEvent) =>
             {
                 DailyPnL = pnlEvent.DailyPnl;
                 RealizedPnL = pnlEvent.RealizedPnl;
@@ -301,7 +305,7 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(PnlSingleMessage), (PnlSingleMessage pnlSingleEvent) =>
+            Connection.On(nameof(PnlSingleMessage), (PnlSingleMessage pnlSingleEvent) =>
             {
                 var ix = Positions.FindIndex(c => c.PositionId == pnlSingleEvent.RequestId);
                 var position = Positions[ix];
@@ -312,7 +316,7 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(AccountSummaryMessage), (AccountSummaryMessage accountSummaryEvent) =>
+            Connection.On(nameof(AccountSummaryMessage), (AccountSummaryMessage accountSummaryEvent) =>
             {
                 switch (accountSummaryEvent.Tag)
                 {
@@ -332,16 +336,16 @@ namespace traderui.Client.Pages
                 StateHasChanged();
             });
 
-            connection.On(nameof(OpenOrderMessage), (OpenOrderMessage openOrderEvent) =>
+            Connection.On(nameof(OpenOrderMessage), (OpenOrderMessage openOrderEvent) =>
             {
                 Console.WriteLine(openOrderEvent.OrderState.Status);
             });
 
-            connection.On(nameof(OrderStatusMessage), (OrderStatusMessage orderStatusEvent) =>
+            Connection.On(nameof(OrderStatusMessage), (OrderStatusMessage orderStatusEvent) =>
             {
             });
 
-            connection.On(nameof(TickPriceMessage), (TickPriceMessage tickPriceEvent) =>
+            Connection.On(nameof(TickPriceMessage), (TickPriceMessage tickPriceEvent) =>
             {
                 /*
                  See this matrix for details for TickId and TickName
@@ -379,7 +383,7 @@ namespace traderui.Client.Pages
                 }
             });
 
-            connection.On(nameof(TickSizeMessage), (TickSizeMessage tickSizeMessage) =>
+            Connection.On(nameof(TickSizeMessage), (TickSizeMessage tickSizeMessage) =>
             {
                 switch (tickSizeMessage.Field)
                 {
@@ -392,25 +396,26 @@ namespace traderui.Client.Pages
                 }
             });
 
-            connection.On(nameof(TickGenericMessage), (TickGenericMessage tickGenericMessage) =>
+            Connection.On(nameof(TickGenericMessage), (TickGenericMessage tickGenericMessage) =>
             {
             });
 
-            connection.On(nameof(TickByTickBidAskMessage), (TickByTickBidAskMessage tickByTickBidAskEvent) =>
+            Connection.On(nameof(TickByTickBidAskMessage), (TickByTickBidAskMessage tickByTickBidAskEvent) =>
             {
                 AskPrice = tickByTickBidAskEvent.AskPrice;
                 BidPrice = tickByTickBidAskEvent.BidPrice;
                 RecalculateNumbers();
             });
 
-            connection.On<string>("log", (obj) =>
+            Connection.On<string>("log", (obj) =>
             {
                 AddLogMessage(obj);
                 StateHasChanged();
             });
 
             // Initialize SignalR connection
-            await connection.StartAsync();
+            await Connection.StartAsync();
+            BrokerService.SetConnectionId(Connection.ConnectionId);
 
             // Request basic account details
             await BrokerService.GetAccountSummary(false, CancellationToken.None);
@@ -425,6 +430,7 @@ namespace traderui.Client.Pages
         public async void OnSymbolChange()
         {
             AdrData.Clear();
+            TempSymbol = TempSymbol?.ToUpper();
             Symbol = TempSymbol;
             await BrokerService.GetTicker(Symbol, CancellationToken.None);
             StateHasChanged();
@@ -557,7 +563,7 @@ namespace traderui.Client.Pages
             OverrideStopLoss = 0;
             OverrideTakeProfitAt = 0;
             OverrideTakeProfitAtPercent = 0;
-
+            OnSymbolChange();
             BrokerService.GetTickerPrice(Symbol, CancellationToken.None);
         }
 

--- a/Client/Services/BrokerService.cs
+++ b/Client/Services/BrokerService.cs
@@ -7,6 +7,7 @@ namespace traderui.Client.Services;
 public class BrokerService : IBrokerService
 {
     private readonly HttpClient _httpClient;
+    private string _connectionId;
 
     public BrokerService(HttpClient httpClient)
     {
@@ -15,17 +16,17 @@ public class BrokerService : IBrokerService
 
     public async Task GetTicker(string name, CancellationToken cancellationToken)
     {
-        await _httpClient.GetAsync($"api/broker/ticker/{name}", cancellationToken);
+        await _httpClient.GetAsync($"api/broker/ticker/{name}/{_connectionId}", cancellationToken);
     }
 
     public async Task GetTickerPrice(string name, CancellationToken cancellationToken)
     {
-        await _httpClient.GetAsync($"api/broker/ticker/{name}/price", cancellationToken);
+        await _httpClient.GetAsync($"api/broker/ticker/{name}/price/{_connectionId}", cancellationToken);
     }
 
     public async Task GetHistoricalBarData(string name, int requestId, CancellationToken cancellationToken)
     {
-        await _httpClient.GetAsync($"api/broker/ticker/{name}/historicbardata/{requestId}", cancellationToken);
+        await _httpClient.GetAsync($"api/broker/ticker/{name}/historicbardata/{requestId}/{_connectionId}", cancellationToken);
     }
 
     public async Task BuyOrder(string name, PlaceOrderRequest orderRequest, CancellationToken cancellationToken)
@@ -63,5 +64,10 @@ public class BrokerService : IBrokerService
     public async Task CancelSubscriptions(CancellationToken cancellationToken)
     {
         await _httpClient.GetAsync($"api/broker/cancelSubscriptions", cancellationToken);
+    }
+
+    public void SetConnectionId(string connectionId)
+    {
+        _connectionId = connectionId;
     }
 }

--- a/Client/Services/IBrokerService.cs
+++ b/Client/Services/IBrokerService.cs
@@ -13,4 +13,5 @@ public interface IBrokerService
     Task GetTickerPnL(string account, int conId, bool active, CancellationToken cancellation);
     Task CancelSubscriptions(CancellationToken cancellation);
     Task GetHistoricalBarData(string name, int requestId, CancellationToken cancellationToken);
+    void SetConnectionId(string connectionId);
 }

--- a/Server/Commands/CancelSubscriptionsCommandHandler.cs
+++ b/Server/Commands/CancelSubscriptionsCommandHandler.cs
@@ -16,7 +16,7 @@ namespace traderui.Server.Commands
 
         public Task<Unit> Handle(CancelSubscriptionsCommand request, CancellationToken cancellationToken)
         {
-            _broker.CancelSubscriptions();
+            // _broker.CancelSubscriptions();
             return Task.FromResult(new Unit());
         }
     }

--- a/Server/Commands/GetHistoricDataCommand.cs
+++ b/Server/Commands/GetHistoricDataCommand.cs
@@ -5,5 +5,6 @@ namespace traderui.Server.Controllers
     public class GetHistoricDataCommand: IRequest<Unit>
     {
         public string Symbol { get; set; }
+        public string ConnectionId { get; set; }
     }
 }

--- a/Server/Commands/GetHistoricDataCommandHandler.cs
+++ b/Server/Commands/GetHistoricDataCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Serilog;
 using traderui.Server.Controllers;
+using traderui.Server.Hubs;
 using traderui.Server.IBKR;
 
 namespace traderui.Server.Commands
@@ -8,14 +9,17 @@ namespace traderui.Server.Commands
     public class GetHistoricDataCommandHandler : IRequestHandler<GetHistoricDataCommand, Unit>
     {
         private readonly IInteractiveBrokers _broker;
+        private readonly BrokerHubService _brokerHubService;
 
-        public GetHistoricDataCommandHandler(IInteractiveBrokers broker)
+        public GetHistoricDataCommandHandler(IInteractiveBrokers broker, BrokerHubService brokerHubService)
         {
             _broker = broker;
+            _brokerHubService = brokerHubService;
         }
 
         public Task<Unit> Handle(GetHistoricDataCommand request, CancellationToken cancellationToken)
         {
+            _brokerHubService.AddToGroup(request.ConnectionId, request.Symbol);
             _broker.GetHistoricPrice(request.Symbol);
             return Task.FromResult(new Unit());
         }

--- a/Server/Commands/GetHistoricalBarDataCommand.cs
+++ b/Server/Commands/GetHistoricalBarDataCommand.cs
@@ -6,5 +6,6 @@ namespace traderui.Server.Controllers
     {
         public string Symbol { get; set; }
         public int RequestId { get; set; }
+        public string ConnectionId { get; set; }
     }
 }

--- a/Server/Commands/GetHistoricalBarDataCommandHandler.cs
+++ b/Server/Commands/GetHistoricalBarDataCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Serilog;
 using traderui.Server.Controllers;
+using traderui.Server.Hubs;
 using traderui.Server.IBKR;
 
 namespace traderui.Server.Commands
@@ -8,10 +9,12 @@ namespace traderui.Server.Commands
     public class GetHistoricalBarDataCommandHandler : IRequestHandler<GetHistoricalBarDataCommand, Unit>
     {
         private readonly IInteractiveBrokers _broker;
+        private readonly BrokerHubService _brokerHubService;
 
-        public GetHistoricalBarDataCommandHandler(IInteractiveBrokers broker)
+        public GetHistoricalBarDataCommandHandler(IInteractiveBrokers broker, BrokerHubService brokerHubService)
         {
             _broker = broker;
+            _brokerHubService = brokerHubService;
         }
 
         public Task<Unit> Handle(GetHistoricalBarDataCommand request, CancellationToken cancellationToken)

--- a/Server/Commands/GetTickerCommand.cs
+++ b/Server/Commands/GetTickerCommand.cs
@@ -5,5 +5,6 @@ namespace traderui.Server.Commands
     public class GetTickerCommand : IRequest<Unit>
     {
         public string Symbol { get; set; }
+        public string ConnectionId { get; set; }
     }
 }

--- a/Server/Commands/GetTickerCommandHandler.cs
+++ b/Server/Commands/GetTickerCommandHandler.cs
@@ -1,5 +1,7 @@
 using MediatR;
+using Microsoft.AspNetCore.SignalR;
 using Serilog;
+using traderui.Server.Hubs;
 using traderui.Server.IBKR;
 
 namespace traderui.Server.Commands
@@ -7,15 +9,18 @@ namespace traderui.Server.Commands
     public class GetTickerCommandHandler : IRequestHandler<GetTickerCommand, Unit>
     {
         private readonly IInteractiveBrokers _broker;
+        private readonly BrokerHubService _brokerHubService;
 
-        public GetTickerCommandHandler(IInteractiveBrokers broker)
+        public GetTickerCommandHandler(IInteractiveBrokers broker, BrokerHubService brokerHubService)
         {
             _broker = broker;
+            _brokerHubService = brokerHubService;
         }
 
         public Task<Unit> Handle(GetTickerCommand request, CancellationToken cancellationToken)
         {
             Log.Information("Requesting Symbol information for {Name}", request.Symbol);
+            _brokerHubService.AddToGroup(request.ConnectionId, request.Symbol);
             _broker.GetTicker(request.Symbol);
             return Task.FromResult(new Unit());
         }

--- a/Server/Commands/GetTickerPriceCommand.cs
+++ b/Server/Commands/GetTickerPriceCommand.cs
@@ -5,5 +5,6 @@ namespace traderui.Server.Controllers
     public class GetTickerPriceCommand : IRequest<Unit>
     {
         public string Symbol { get; set; }
+        public string ConnectionId { get; set; }
     }
 }

--- a/Server/Commands/GetTickerPriceCommandHandler.cs
+++ b/Server/Commands/GetTickerPriceCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Serilog;
 using traderui.Server.Controllers;
+using traderui.Server.Hubs;
 using traderui.Server.IBKR;
 
 namespace traderui.Server.Commands
@@ -8,14 +9,17 @@ namespace traderui.Server.Commands
     public class GetTickerPriceCommandHandler : IRequestHandler<GetTickerPriceCommand, Unit>
     {
         private readonly IInteractiveBrokers _broker;
+        private readonly BrokerHubService _brokerHubService;
 
-        public GetTickerPriceCommandHandler(IInteractiveBrokers broker)
+        public GetTickerPriceCommandHandler(IInteractiveBrokers broker, BrokerHubService brokerHubService)
         {
             _broker = broker;
+            _brokerHubService = brokerHubService;
         }
 
         public Task<Unit> Handle(GetTickerPriceCommand request, CancellationToken cancellationToken)
         {
+            _brokerHubService.AddToGroup(request.ConnectionId, request.Symbol);
             _broker.GetTickerPrice(request.Symbol);
             return Task.FromResult(new Unit());
         }

--- a/Server/Controllers/BrokerController.cs
+++ b/Server/Controllers/BrokerController.cs
@@ -31,43 +31,49 @@ namespace traderui.Server.Controllers
             _mapper = mapper;
         }
 
-        [HttpGet("ticker/{symbol}")]
-        public IActionResult Get(string symbol)
+        [HttpGet("ticker/{symbol}/{connectionId}")]
+        public IActionResult Get(string symbol, string connectionId)
         {
             _mediator.Send(new GetTickerCommand
             {
                 Symbol = symbol,
+                ConnectionId = connectionId
             });
 
             return Ok();
         }
 
-        [HttpGet("ticker/{symbol}/price")]
-        public IActionResult UpdatePrice(string symbol)
+        [HttpGet("ticker/{symbol}/price/{connectionId}")]
+        public IActionResult UpdatePrice(string symbol,string connectionId)
         {
             _mediator.Send(new GetTickerPriceCommand
             {
                 Symbol = symbol,
+                ConnectionId = connectionId
+
             });
             return Ok();
         }
 
         [HttpGet("ticker/{symbol}/historic")]
-        public IActionResult GetHistoricData(string symbol)
+        public IActionResult GetHistoricData(string symbol,string connectionId)
         {
             _mediator.Send(new GetHistoricDataCommand
             {
                 Symbol = symbol,
+                ConnectionId = connectionId
             });
             return Ok();
         }
 
-        [HttpGet("ticker/{symbol}/historicbardata/{requestId}")]
-        public IActionResult GetHistoricalBarData(string symbol, int requestId)
+        [HttpGet("ticker/{symbol}/historicbardata/{requestId}/{connectionId}")]
+        public IActionResult GetHistoricalBarData(string symbol, int requestId, string connectionId)
         {
             _mediator.Send(new GetHistoricalBarDataCommand
             {
-                Symbol = symbol, RequestId = requestId,
+                Symbol = symbol,
+                ConnectionId = connectionId,
+                RequestId = requestId,
             });
             return Ok();
         }

--- a/Server/Hubs/BrokerHubService.cs
+++ b/Server/Hubs/BrokerHubService.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+
+namespace traderui.Server.Hubs
+{
+    public class BrokerHubService
+    {
+        private readonly IHubContext<BrokerHub> _hubContext;
+        public List<string> ListOfSymbolGroups { get; set; } = new List<string>();
+
+        public BrokerHubService(IHubContext<BrokerHub> hubContext)
+        {
+            _hubContext = hubContext;
+        }
+
+        public void AddToGroup(string connectionId, string groupName)
+        {
+            Log.Information("Adding {ConnectionId} to {groupName} notifications", connectionId, groupName);
+            var name = groupName.ToUpper();
+
+            ListOfSymbolGroups.ForEach(g => _hubContext.Groups.RemoveFromGroupAsync(connectionId, g));
+            if (!ListOfSymbolGroups.Any(g => g.Equals(name)))
+            {
+                ListOfSymbolGroups.Add(name);
+            }
+
+            _hubContext.Groups.AddToGroupAsync(connectionId, name);
+        }
+
+        public void RemoveFromGroup(string connectionId)
+        {
+            Log.Information("Removing {ConnectionId} from all notifications", connectionId);
+            ListOfSymbolGroups.ForEach(g => _hubContext.Groups.RemoveFromGroupAsync(connectionId, g));
+        }
+    }
+}

--- a/Server/InteractiveBrokers/EWrapperImplementation.cs
+++ b/Server/InteractiveBrokers/EWrapperImplementation.cs
@@ -78,7 +78,7 @@ public class EWrapperImplementation : EWrapper
 
     public void tickPrice(int tickerId, int field, double price, TickAttrib attribs)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(TickPriceMessage), new TickPriceMessage
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(tickerId)).SendAsync(nameof(TickPriceMessage), new TickPriceMessage
         {
             TickerId = tickerId,
             Field = field,
@@ -89,7 +89,7 @@ public class EWrapperImplementation : EWrapper
 
     public void tickSize(int tickerId, int field, int size)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(TickSizeMessage), new TickSizeMessage
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(tickerId)).SendAsync(nameof(TickSizeMessage), new TickSizeMessage
         {
             TickerId = tickerId,
             Field = field,
@@ -103,7 +103,7 @@ public class EWrapperImplementation : EWrapper
 
     public void tickGeneric(int tickerId, int field, double value)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(TickGenericMessage), new TickGenericMessage
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(tickerId)).SendAsync(nameof(TickGenericMessage), new TickGenericMessage
         {
             TickerId = tickerId,
             Field = field,
@@ -218,7 +218,7 @@ public class EWrapperImplementation : EWrapper
 
     public void contractDetails(int reqId, ContractDetails contractDetails)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(ContractDetailsMessage), new ContractDetailsMessage {RequestId = reqId, ContractDetails = contractDetails});
+        _brokerHub.Clients.Group(contractDetails.Contract.Symbol).SendAsync(nameof(ContractDetailsMessage), new ContractDetailsMessage {RequestId = reqId, ContractDetails = contractDetails});
     }
 
     public void contractDetailsEnd(int reqId)
@@ -243,17 +243,18 @@ public class EWrapperImplementation : EWrapper
 
     public void historicalData(int reqId, Bar bar)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(HistoricalDataMessage), new HistoricalDataMessage {RequestId = reqId, Bar = bar,});
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(reqId)).SendAsync(nameof(HistoricalDataMessage), new HistoricalDataMessage {RequestId = reqId, Bar = bar,});
+        // _brokerHub.Clients.All.SendAsync(nameof(HistoricalDataMessage), new HistoricalDataMessage {RequestId = reqId, Bar = bar,});
     }
 
     public void historicalDataUpdate(int reqId, Bar bar)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(HistoricalDataUpdateMessage), new HistoricalDataUpdateMessage {RequestId = reqId, Bar = bar,});
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(reqId)).SendAsync(nameof(HistoricalDataUpdateMessage), new HistoricalDataUpdateMessage {RequestId = reqId, Bar = bar,});
     }
 
     public void historicalDataEnd(int reqId, string start, string end)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(HistoricalDataEndMessage), new HistoricalDataEndMessage {RequestId = reqId, Start = start, End = end,});
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(reqId)).SendAsync(nameof(HistoricalDataEndMessage), new HistoricalDataEndMessage {RequestId = reqId, Start = start, End = end,});
     }
 
     public void marketDataType(int reqId, int marketDataType)
@@ -467,7 +468,7 @@ public class EWrapperImplementation : EWrapper
 
     public void tickByTickBidAsk(int reqId, long time, double bidPrice, double askPrice, int bidSize, int askSize, TickAttribBidAsk tickAttribBidAsk)
     {
-        _brokerHub.Clients.All.SendAsync(nameof(TickByTickBidAskMessage), new TickByTickBidAskMessage
+        _brokerHub.Clients.Group(_broker.GetSymbolNameFromRequestId(reqId)).SendAsync(nameof(TickByTickBidAskMessage), new TickByTickBidAskMessage
         {
             RequestId = reqId,
             Time = time,

--- a/Server/InteractiveBrokers/IInteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/IInteractiveBrokers.cs
@@ -18,5 +18,6 @@ namespace traderui.Server.IBKR
         bool IsConnected();
         void ModifyProfitOrderWithCorrectQuantity(int orderId, double filled);
         void Connect();
+        string GetSymbolNameFromRequestId(int reqId);
     }
 }

--- a/Server/InteractiveBrokers/InteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/InteractiveBrokers.cs
@@ -2,6 +2,7 @@ using IBApi;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 using Serilog;
+using System.ComponentModel.DataAnnotations;
 using traderui.Server.Hubs;
 using traderui.Shared;
 using traderui.Shared.Events;
@@ -21,6 +22,8 @@ namespace traderui.Server.IBKR
         private CancellationTokenSource _connectionToken;
         private Dictionary<string, int> CurrentRequestStack { get; set; } = new Dictionary<string, int>();
         private Dictionary<string, int> GetPriceRequestStack { get; set; } = new Dictionary<string, int>();
+
+        private Dictionary<int, string> RequestIdToSymbol { get; set; } = new Dictionary<int, string>();
 
         private Dictionary<int, Order> OrderToModify { get; set; } = new();
         private Dictionary<int, Contract> ContractOfOrdersToModify { get; set; } = new();
@@ -201,6 +204,12 @@ namespace traderui.Server.IBKR
             }
         }
 
+        public string GetSymbolNameFromRequestId(int requestId)
+        {
+            // Log.Information("Symbol for {requestId} = {symbol}", requestId, RequestIdToSymbol[requestId]);
+            return RequestIdToSymbol[requestId];
+        }
+
         public void GetTickerPnL(string account, int conId, bool active)
         {
             try
@@ -231,6 +240,12 @@ namespace traderui.Server.IBKR
             GetPriceRequestStack.Clear();
         }
 
+        public void CancelSubscriptions(int requestId)
+        {
+            _client.cancelMktData(requestId);
+            _client.cancelHistoricalData(requestId);
+        }
+
         public void GetHistoricPrice(string name)
         {
             Contract contract = new Contract
@@ -243,8 +258,10 @@ namespace traderui.Server.IBKR
                 Exchange = "SMART"
             };
 
+            var requestId = _random.Next();
+            RequestIdToSymbol.Add(requestId, name);
             String queryTime = $"{DateTime.Now.ToString("yyyyMMdd")} 23:59:59";
-            _client.reqHistoricalData(_random.Next(), contract, String.Empty, "1 D", "1 day", "TRADES", 1, 1, true, null);
+            _client.reqHistoricalData(requestId, contract, String.Empty, "1 D", "1 day", "TRADES", 1, 1, true, null);
         }
 
         public void GetTicker(string name)
@@ -259,6 +276,22 @@ namespace traderui.Server.IBKR
                 Exchange = "SMART"
             };
             var newRequestId = _random.Next();
+
+            if (RequestIdToSymbol.ContainsValue(name))
+            {
+                foreach (var kv in RequestIdToSymbol)
+                {
+                    if (kv.Value == name)
+                    {
+                        newRequestId = kv.Key;
+                    }
+                }
+            }
+            else
+            {
+                RequestIdToSymbol.Add(newRequestId, name);
+            }
+
             _client.reqIds(-1);
             _client.reqContractDetails(newRequestId, contract);
         }
@@ -268,7 +301,7 @@ namespace traderui.Server.IBKR
             _client.reqMarketDataType(1);
             var requestId = _random.Next();
 
-            CancelSubscriptions();
+            // CancelSubscriptions();
 
             Contract contract = new Contract
             {
@@ -280,7 +313,15 @@ namespace traderui.Server.IBKR
                 Exchange = "SMART"
             };
 
-            GetPriceRequestStack.Add(name, requestId);
+            if (!GetPriceRequestStack.ContainsKey(name))
+            {
+                GetPriceRequestStack.Add(name, requestId);
+            }
+
+            if (!RequestIdToSymbol.ContainsKey(requestId))
+            {
+                RequestIdToSymbol.Add(requestId, name);
+            }
 
             Log.Information("Requested market data for {name}", name);
             _client.reqMktData(requestId, contract, "165, 221,233,295,595", false, false, null);
@@ -299,6 +340,11 @@ namespace traderui.Server.IBKR
                 Exchange = "SMART"
             };
             // String queryTime = DateTime.Now.AddMonths(-1).ToString("yyyyMMdd HH:mm:ss");
+            if (!RequestIdToSymbol.ContainsKey(requestId))
+            {
+                RequestIdToSymbol.Add(requestId, name);
+            }
+
             _client.reqHistoricalData(requestId, contract, String.Empty, "20 D", "1 day", "TRADES", 1, 1, false, null);
         }
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddSignalR();
 builder.Services.AddSingleton<IInteractiveBrokers, InteractiveBrokers>();
+builder.Services.AddSingleton<BrokerHubService>();
 builder.Services.Configure<ApiBehaviorOptions>(options =>
 {
     options.SuppressModelStateInvalidFilter = true;

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -21,6 +21,13 @@
       }
     ]
   },
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://+:5000"
+      }
+    }
+  },
   "ServerOptions":{
     "Server": "localhost",
     "Port": 7497,


### PR DESCRIPTION
To have more than one instance of the application running (i.e mobile phone, or multiple tabs in browser) we need to only send symbol information to the instances that needs it. Using groups with SignalR helps solving this.