### PR TITLE
bugfix: #26 - Only transmit on the primary stop-loss order

### DIFF
--- a/Server/InteractiveBrokers/InteractiveBrokers.cs
+++ b/Server/InteractiveBrokers/InteractiveBrokers.cs
@@ -383,7 +383,7 @@ namespace traderui.Server.IBKR
                     TotalQuantity = webOrder.Qty - numberOfOrdersToSell,
                     AuxPrice = Math.Round(webOrder.Price, numberOfDecimals, MidpointRounding.ToZero),
                     LmtPrice = Math.Round(webOrder.Price, numberOfDecimals, MidpointRounding.ToZero),
-                    Transmit = webOrder.Transmit,
+                    Transmit = false,
                     Tif = "GTC" // Good til canceled
                 };
                 _client.placeOrder(profitStopLoss.OrderId, webOrder.ContractDetails.Contract, profitStopLoss);


### PR DESCRIPTION
Solves #26 where we have an issue where the primary stop-loss order is cancelled on transmit with `[15:46:21 WRN] 201 - Order rejected - reason:Parent order is being cancelled.`

This happens because the partial stop-loss order is transmitted before the primary stop-loss.